### PR TITLE
fix: homepage client-side navigation showing not found

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -51,12 +51,6 @@ const nextConfig: NextConfig = {
       permanent: true,
     },
   ],
-  rewrites: () => [
-    {
-      source: '/',
-      destination: '/home',
-    },
-  ],
 }
 
 export default nextConfig

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next'
+
+import CatchAllPage, {
+  generateMetadata as catchAllGenerateMetadata,
+} from './[...path]/page'
+
+const homeParams = Promise.resolve({ path: ['home'] })
+
+export const generateMetadata = (): Promise<Metadata> =>
+  catchAllGenerateMetadata({ params: homeParams })
+
+export default function HomePage() {
+  return <CatchAllPage params={homeParams} />
+}


### PR DESCRIPTION
The rewrite rule (/ → /home) in next.config.ts only applies server-side. Client-side <Link href="/"> navigation bypassed it, causing the [...path] catch-all to receive an empty path array and trigger notFound().

Add a root page.tsx that imports the catch-all page component with path hardcoded to ['home'], and remove the now-unnecessary rewrite.